### PR TITLE
feat: add --wait-for-agent flag to exec command

### DIFF
--- a/pkg/cmd/exec.go
+++ b/pkg/cmd/exec.go
@@ -35,7 +35,7 @@ type execRequest struct {
 	Env          map[string]string `json:"env,omitempty"`
 	Cwd          string            `json:"cwd,omitempty"`
 	Timeout      int32             `json:"timeout,omitempty"`
-	WaitForAgent int32             `json:"wait_for_agent,omitempty"`
+	WaitForAgent int32             `json:"wait_for_agent"`
 }
 
 var execCmd = cli.Command{


### PR DESCRIPTION
## Summary

Adds a `--wait-for-agent` flag to the `exec` command that allows the CLI to wait for the guest agent to become ready before executing commands.

## Motivation

When a VM is still booting, the guest agent may not be ready immediately. Previously, `hypeman exec` would fail immediately if the agent wasn't responding. This was especially problematic for:
- Newly started VMs
- VMs running systemd images (which have longer boot times)
- Scripts that run `hypeman exec` immediately after `hypeman run`

## Changes

- Added `--wait-for-agent` flag with a **default of 30 seconds**
- The flag accepts seconds (e.g., `--wait-for-agent=60` for 60 seconds)
- Use `--wait-for-agent=0` to fail immediately (old behavior)
- Added `wait_for_agent` field to the exec request JSON

## Usage

```bash
# Default: waits up to 30 seconds for agent
hypeman exec my-instance whoami

# Wait up to 60 seconds
hypeman exec --wait-for-agent=60 my-instance whoami

# Fail immediately if agent not ready
hypeman exec --wait-for-agent=0 my-instance whoami
```

## Dependencies

This PR depends on the server-side support in:
- https://github.com/onkernel/hypeman/pull/50

The `wait_for_agent` field is passed to the exec endpoint, which will retry connecting to the guest agent on `AgentConnectionError` until the timeout expires.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a configurable wait period for the guest agent before executing commands.
> 
> - Adds `--wait-for-agent` CLI flag (default 30s; `0` to fail immediately) to `exec` command
> - Extends exec request with `wait_for_agent` field and sets it in `handleExec` based on the flag
> - No other behavior changes; existing flags and execution flow remain intact
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1cd1f620ae3d407f9f3a26c665e5c567df8d217. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->