### PR TITLE
fix: align pull with image create and improve reclaim size input

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ go run cmd/hypeman/main.go
 ## Usage
 
 ```sh
-# Create an image (or use `hypeman pull` as an alias)
-hypeman image create nginx:alpine
+# Pull an image
+hypeman pull nginx:alpine
 
 # Boot a new VM (auto-pulls image if needed)
 hypeman run --name my-app nginx:alpine

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ go run cmd/hypeman/main.go
 ## Usage
 
 ```sh
-# Pull an image
-hypeman pull nginx:alpine
+# Create an image (or use `hypeman pull` as an alias)
+hypeman image create nginx:alpine
 
 # Boot a new VM (auto-pulls image if needed)
 hypeman run --name my-app nginx:alpine

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kernel/hypeman-cli
 go 1.25
 
 require (
+	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
+github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500 h1:6lhrsTEnloDPXyeZBvSYvQf8u86jbKehZPVDDlkgDl4=
+github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/charmbracelet/bubbles v0.21.0 h1:9TdC97SdRVg/1aaXNVWfFH3nnLAwOXr8Fn6u6mfQdFs=

--- a/pkg/cmd/imagecmd.go
+++ b/pkg/cmd/imagecmd.go
@@ -25,15 +25,10 @@ var imageCmd = cli.Command{
 }
 
 var imageCreateCmd = cli.Command{
-	Name:      "create",
-	Usage:     "Pull and convert an OCI image",
-	ArgsUsage: "<name>",
-	Flags: []cli.Flag{
-		&cli.StringSliceFlag{
-			Name:  "tag",
-			Usage: "Set image tag key-value pair (KEY=VALUE, can be repeated)",
-		},
-	},
+	Name:            "create",
+	Usage:           "Pull and convert an OCI image",
+	ArgsUsage:       "<name>",
+	Flags:           imageCreateFlags(),
 	Action:          handleImageCreate,
 	HideHelpCommand: true,
 }
@@ -149,23 +144,20 @@ func handleImageList(ctx context.Context, cmd *cli.Command) error {
 }
 
 func handleImageCreate(ctx context.Context, cmd *cli.Command) error {
+	return handleImageCreateLike(ctx, cmd, "hypeman image create <name>", "image create")
+}
+
+func handleImageCreateLike(ctx context.Context, cmd *cli.Command, usageLine, outputLabel string) error {
 	args := cmd.Args().Slice()
 	if len(args) < 1 {
-		return fmt.Errorf("image name required\nUsage: hypeman image create <name>")
+		return fmt.Errorf("image name required\nUsage: %s", usageLine)
 	}
 
 	client := hypeman.NewClient(getDefaultRequestOptions(cmd)...)
 
-	params := hypeman.ImageNewParams{
-		Name: args[0],
-	}
-
-	tags, malformedTags := parseKeyValueSpecs(cmd.StringSlice("tag"))
+	params, malformedTags := buildImageNewParams(args[0], cmd.StringSlice("tag"))
 	for _, malformed := range malformedTags {
 		fmt.Fprintf(os.Stderr, "Warning: ignoring malformed tag: %s\n", malformed)
-	}
-	if len(tags) > 0 {
-		params.Tags = tags
 	}
 
 	var opts []option.RequestOption
@@ -184,7 +176,7 @@ func handleImageCreate(ctx context.Context, cmd *cli.Command) error {
 			return err
 		}
 		obj := gjson.ParseBytes(res)
-		return ShowJSON(os.Stdout, "image create", obj, format, transform)
+		return ShowJSON(os.Stdout, outputLabel, obj, format, transform)
 	}
 
 	result, err := client.Images.New(ctx, params, opts...)
@@ -193,6 +185,26 @@ func handleImageCreate(ctx context.Context, cmd *cli.Command) error {
 	}
 	fmt.Println(result.Name)
 	return nil
+}
+
+func imageCreateFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringSliceFlag{
+			Name:  "tag",
+			Usage: "Set image tag key-value pair (KEY=VALUE, can be repeated)",
+		},
+	}
+}
+
+func buildImageNewParams(name string, tagSpecs []string) (hypeman.ImageNewParams, []string) {
+	params := hypeman.ImageNewParams{Name: name}
+
+	tags, malformedTags := parseKeyValueSpecs(tagSpecs)
+	if len(tags) > 0 {
+		params.Tags = tags
+	}
+
+	return params, malformedTags
 }
 
 func handleImageGet(ctx context.Context, cmd *cli.Command) error {

--- a/pkg/cmd/imagecmd_test.go
+++ b/pkg/cmd/imagecmd_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildImageNewParams(t *testing.T) {
+	params, malformed := buildImageNewParams("docker.io/library/alpine:latest", []string{
+		"env=staging",
+		"team=cli",
+		"missing-delimiter",
+	})
+
+	require.Equal(t, "docker.io/library/alpine:latest", params.Name)
+	assert.Equal(t, map[string]string{
+		"env":  "staging",
+		"team": "cli",
+	}, params.Tags)
+	assert.Equal(t, []string{"missing-delimiter"}, malformed)
+}

--- a/pkg/cmd/pull.go
+++ b/pkg/cmd/pull.go
@@ -2,7 +2,12 @@ package cmd
 
 import (
 	"context"
+	"fmt"
+	"os"
 
+	"github.com/kernel/hypeman-go"
+	"github.com/kernel/hypeman-go/option"
+	"github.com/tidwall/gjson"
 	"github.com/urfave/cli/v3"
 )
 
@@ -16,5 +21,50 @@ var pullCmd = cli.Command{
 }
 
 func handlePull(ctx context.Context, cmd *cli.Command) error {
-	return handleImageCreateLike(ctx, cmd, "hypeman pull <image>", "pull")
+	args := cmd.Args().Slice()
+	if len(args) < 1 {
+		return fmt.Errorf("image reference required\nUsage: hypeman pull <image>")
+	}
+
+	image := args[0]
+	params, malformedTags := buildImageNewParams(image, cmd.StringSlice("tag"))
+	for _, malformed := range malformedTags {
+		fmt.Fprintf(os.Stderr, "Warning: ignoring malformed tag: %s\n", malformed)
+	}
+
+	client := hypeman.NewClient(getDefaultRequestOptions(cmd)...)
+
+	var opts []option.RequestOption
+	if cmd.Root().Bool("debug") {
+		opts = append(opts, debugMiddlewareOption)
+	}
+
+	format := cmd.Root().String("format")
+	transform := cmd.Root().String("transform")
+
+	if format != "auto" {
+		var res []byte
+		opts = append(opts, option.WithResponseBodyInto(&res))
+		_, err := client.Images.New(ctx, params, opts...)
+		if err != nil {
+			return err
+		}
+		obj := gjson.ParseBytes(res)
+		return ShowJSON(os.Stdout, "pull", obj, format, transform)
+	}
+
+	fmt.Fprintf(os.Stderr, "Pulling %s...\n", image)
+
+	result, err := client.Images.New(ctx, params, opts...)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "Status: %s\n", result.Status)
+	if result.Digest != "" {
+		fmt.Fprintf(os.Stderr, "Digest: %s\n", result.Digest)
+	}
+	fmt.Fprintf(os.Stderr, "Image: %s\n", result.Name)
+
+	return nil
 }

--- a/pkg/cmd/pull.go
+++ b/pkg/cmd/pull.go
@@ -2,57 +2,19 @@ package cmd
 
 import (
 	"context"
-	"fmt"
-	"os"
 
-	"github.com/kernel/hypeman-go"
-	"github.com/kernel/hypeman-go/option"
 	"github.com/urfave/cli/v3"
 )
 
 var pullCmd = cli.Command{
 	Name:            "pull",
-	Usage:           "Pull an image from a registry",
+	Usage:           "Alias for `image create`",
 	ArgsUsage:       "<image>",
+	Flags:           imageCreateFlags(),
 	Action:          handlePull,
 	HideHelpCommand: true,
 }
 
 func handlePull(ctx context.Context, cmd *cli.Command) error {
-	args := cmd.Args().Slice()
-	if len(args) < 1 {
-		return fmt.Errorf("image reference required\nUsage: hypeman pull <image>")
-	}
-
-	image := args[0]
-
-	fmt.Fprintf(os.Stderr, "Pulling %s...\n", image)
-
-	client := hypeman.NewClient(getDefaultRequestOptions(cmd)...)
-
-	params := hypeman.ImageNewParams{
-		Name: image,
-	}
-
-	var opts []option.RequestOption
-	if cmd.Root().Bool("debug") {
-		opts = append(opts, debugMiddlewareOption)
-	}
-
-	result, err := client.Images.New(
-		ctx,
-		params,
-		opts...,
-	)
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintf(os.Stderr, "Status: %s\n", result.Status)
-	if result.Digest != "" {
-		fmt.Fprintf(os.Stderr, "Digest: %s\n", result.Digest)
-	}
-	fmt.Fprintf(os.Stderr, "Image: %s\n", result.Name)
-
-	return nil
+	return handleImageCreateLike(ctx, cmd, "hypeman pull <image>", "pull")
 }

--- a/pkg/cmd/resourcecmd.go
+++ b/pkg/cmd/resourcecmd.go
@@ -3,9 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/kernel/hypeman-go"
 	"github.com/kernel/hypeman-go/option"
 	"github.com/tidwall/gjson"
@@ -39,10 +41,15 @@ Examples:
 var resourcesReclaimMemoryCmd = cli.Command{
 	Name:  "reclaim-memory",
 	Usage: "Request guest memory reclaim from reclaim-eligible instances",
+	Description: `Request guest memory reclaim across eligible instances.
+
+Examples:
+  hypeman resources reclaim-memory --reclaim-bytes 512MB --dry-run
+  hypeman resources reclaim-memory --reclaim-bytes 1073741824 --hold-for 10m --reason "pack host before launch"`,
 	Flags: []cli.Flag{
-		&cli.Int64Flag{
+		&cli.StringFlag{
 			Name:     "reclaim-bytes",
-			Usage:    "Total bytes of guest memory to reclaim across eligible VMs",
+			Usage:    `Total guest memory to reclaim (e.g., "512MB", "2GB", or "1048576" for raw bytes)`,
 			Required: true,
 		},
 		&cli.BoolFlag{
@@ -93,9 +100,9 @@ func handleResources(ctx context.Context, cmd *cli.Command) error {
 func handleResourcesReclaimMemory(ctx context.Context, cmd *cli.Command) error {
 	client := hypeman.NewClient(getDefaultRequestOptions(cmd)...)
 
-	reclaimBytes := cmd.Int64("reclaim-bytes")
-	if reclaimBytes <= 0 {
-		return fmt.Errorf("reclaim-bytes must be greater than 0")
+	reclaimBytes, err := parseReclaimBytes(cmd.String("reclaim-bytes"))
+	if err != nil {
+		return err
 	}
 
 	request := hypeman.MemoryReclaimRequestParam{
@@ -122,7 +129,7 @@ func handleResourcesReclaimMemory(ctx context.Context, cmd *cli.Command) error {
 
 	var res []byte
 	opts = append(opts, option.WithResponseBodyInto(&res))
-	_, err := client.Resources.ReclaimMemory(ctx, params, opts...)
+	_, err = client.Resources.ReclaimMemory(ctx, params, opts...)
 	if err != nil {
 		return err
 	}
@@ -141,6 +148,25 @@ func handleResourcesReclaimMemory(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	return ShowJSON(os.Stdout, "resources reclaim-memory", obj, format, transform)
+}
+
+func parseReclaimBytes(raw string) (int64, error) {
+	if raw == "" {
+		return 0, fmt.Errorf("reclaim-bytes is required")
+	}
+
+	var size datasize.ByteSize
+	if err := size.UnmarshalText([]byte(raw)); err != nil {
+		return 0, fmt.Errorf("invalid reclaim-bytes %q: %w", raw, err)
+	}
+	if size == 0 {
+		return 0, fmt.Errorf("reclaim-bytes must be greater than 0")
+	}
+	if size.Bytes() > math.MaxInt64 {
+		return 0, fmt.Errorf("reclaim-bytes %q exceeds the maximum supported size", raw)
+	}
+
+	return int64(size.Bytes()), nil
 }
 
 func showResourcesTable(data []byte) error {

--- a/pkg/cmd/resourcecmd_test.go
+++ b/pkg/cmd/resourcecmd_test.go
@@ -4,7 +4,38 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestParseReclaimBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int64
+		wantErr  string
+	}{
+		{name: "raw bytes", input: "1048576", expected: 1048576},
+		{name: "megabytes", input: "512MB", expected: 512 * 1024 * 1024},
+		{name: "gigabytes with space", input: "2 GB", expected: 2 * 1024 * 1024 * 1024},
+		{name: "empty", input: "", wantErr: "reclaim-bytes is required"},
+		{name: "zero", input: "0", wantErr: "reclaim-bytes must be greater than 0"},
+		{name: "invalid", input: "nope", wantErr: "invalid reclaim-bytes \"nope\""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseReclaimBytes(tt.input)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
 
 func TestFormatBytes(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- make `hypeman pull` use the same image-create request path and `--tag` handling as `hypeman image create`
- preserve the legacy human-readable `pull` auto output, while keeping explicit `--format` output supported
- accept human-readable values for `resources reclaim-memory --reclaim-bytes` while treating bare numbers as raw bytes
- add tests for shared image-create parsing and reclaim-size parsing
- update the README and command help/examples to reflect the new behavior

## Testing
- go test ./...
- go run ./cmd/hypeman pull --help
- go run ./cmd/hypeman image create --help
- go run ./cmd/hypeman resources reclaim-memory --help

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes CLI request/formatting behavior for `pull`/`image create` and alters parsing of `resources reclaim-memory --reclaim-bytes`, which could impact scripts relying on previous outputs or strict numeric inputs.
> 
> **Overview**
> Unifies image creation logic by factoring shared tag parsing/param building into `buildImageNewParams` and reusing it from both `image create` and `pull`, including consistent malformed-tag warnings.
> 
> Updates `hypeman pull` to behave as an alias of `image create`: it now supports `--tag` and, when `--format` is set, returns structured output via `ShowJSON` while preserving the legacy human-readable output when `--format auto`.
> 
> Improves `resources reclaim-memory --reclaim-bytes` to accept human-readable sizes (e.g., `512MB`, `2 GB`) via `datasize`, with validation for empty/zero/overflow inputs, and adds focused unit tests for the new parsing and shared image param builder.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc4c37bc9bf8d20f66e016a1079c351893cf0005. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->