### PR TITLE
Add singular/plural aliases to resource commands

### DIFF
--- a/pkg/cmd/build.go
+++ b/pkg/cmd/build.go
@@ -18,6 +18,7 @@ import (
 
 var buildCmd = cli.Command{
 	Name:      "build",
+	Aliases:   []string{"builds"},
 	Usage:     "Build an image from a Dockerfile",
 	ArgsUsage: "[path]",
 	Description: `Build an image from a Dockerfile and source context.

--- a/pkg/cmd/devicecmd.go
+++ b/pkg/cmd/devicecmd.go
@@ -12,8 +12,9 @@ import (
 )
 
 var deviceCmd = cli.Command{
-	Name:  "device",
-	Usage: "Manage PCI/GPU devices for passthrough",
+	Name:    "device",
+	Aliases: []string{"devices"},
+	Usage:   "Manage PCI/GPU devices for passthrough",
 	Description: `Manage PCI devices for passthrough to virtual machines.
 
 This command allows you to discover available passthrough-capable devices,

--- a/pkg/cmd/imagecmd.go
+++ b/pkg/cmd/imagecmd.go
@@ -13,8 +13,9 @@ import (
 )
 
 var imageCmd = cli.Command{
-	Name:  "image",
-	Usage: "Manage images",
+	Name:    "image",
+	Aliases: []string{"images"},
+	Usage:   "Manage images",
 	Commands: []*cli.Command{
 		&imageCreateCmd,
 		&imageListCmd,

--- a/pkg/cmd/ingresscmd.go
+++ b/pkg/cmd/ingresscmd.go
@@ -13,8 +13,9 @@ import (
 )
 
 var ingressCmd = cli.Command{
-	Name:  "ingress",
-	Usage: "Manage ingresses",
+	Name:    "ingress",
+	Aliases: []string{"ingresses"},
+	Usage:   "Manage ingresses",
 	Commands: []*cli.Command{
 		&ingressCreateCmd,
 		&ingressListCmd,

--- a/pkg/cmd/resourcecmd.go
+++ b/pkg/cmd/resourcecmd.go
@@ -15,8 +15,9 @@ import (
 )
 
 var resourcesCmd = cli.Command{
-	Name:  "resources",
-	Usage: "Show server resource capacity and allocation status",
+	Name:    "resources",
+	Aliases: []string{"resource"},
+	Usage:   "Show server resource capacity and allocation status",
 	Description: `Display current host resource capacity, allocation status, and per-instance breakdown.
 
 Resources include CPU, memory, disk, network, and GPU (if available).

--- a/pkg/cmd/snapshotcmd.go
+++ b/pkg/cmd/snapshotcmd.go
@@ -14,8 +14,9 @@ import (
 )
 
 var snapshotCmd = cli.Command{
-	Name:  "snapshot",
-	Usage: "Manage instance snapshots",
+	Name:    "snapshot",
+	Aliases: []string{"snapshots"},
+	Usage:   "Manage instance snapshots",
 	Commands: []*cli.Command{
 		&snapshotCreateCmd,
 		&snapshotRestoreCmd,

--- a/pkg/cmd/volumecmd.go
+++ b/pkg/cmd/volumecmd.go
@@ -12,8 +12,9 @@ import (
 )
 
 var volumeCmd = cli.Command{
-	Name:  "volume",
-	Usage: "Manage volumes",
+	Name:    "volume",
+	Aliases: []string{"volumes"},
+	Usage:   "Manage volumes",
 	Commands: []*cli.Command{
 		&volumeCreateCmd,
 		&volumeListCmd,


### PR DESCRIPTION
## Summary
- Adds plural aliases to singular resource commands (`image` → `images`, `volume` → `volumes`, etc.)
- Adds singular alias to `resources` → `resource`
- Adds `builds` alias to `build` command
- All subcommands automatically work via either form (e.g. `hypeman images list` = `hypeman image list`)

Uses urfave/cli's built-in `Aliases` field — no structural changes.

## Commands updated
| Primary | Alias |
|---------|-------|
| `image` | `images` |
| `volume` | `volumes` |
| `snapshot` | `snapshots` |
| `device` | `devices` |
| `ingress` | `ingresses` |
| `build` | `builds` |
| `resources` | `resource` |

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds `urfave/cli` command `Aliases` for several top-level commands without changing execution paths, API calls, or data handling.
> 
> **Overview**
> Adds singular/plural aliases for multiple top-level CLI commands so users can invoke the same subcommands via either form (e.g., `image`/`images`, `volume`/`volumes`, `snapshot`/`snapshots`, `device`/`devices`, `ingress`/`ingresses`, `resources`/`resource`, `build`/`builds`). No functional logic changes beyond expanding accepted command names via `urfave/cli`’s `Aliases` field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caff943a3d0aa14d1e47977439a6eaef9b437773. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->