### PR TITLE
ci: add Semgrep SAST scanning on pull requests

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,17 @@
+name: Semgrep
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan:
+    uses: kernel/security-workflows/.github/workflows/semgrep.yml@main
+    with:
+      extra-configs: '--config p/golang --config p/trailofbits'
+      codebase-description: 'Go CLI wrapping the Hypeman (Unikraft Cloud) API, authenticating with user credentials'
+    secrets: inherit


### PR DESCRIPTION
## Summary

Follow-up from the INC-51 postmortem ([KERNEL-1191](https://linear.app/onkernel/issue/KERNEL-1191/finalize-scope-of-repos-under-elevated-vulnerability-management)): expanding the elevated vulnerability management scope to customer-facing tools. This CLI authenticates against the Hypeman/Unikraft Cloud API with user credentials so it qualifies.

This PR adds `.github/workflows/semgrep.yml` that calls the reusable workflow in [kernel/security-workflows](https://github.com/kernel/security-workflows). Runs on every PR targeting \`main\` with the agent-powered triage flow already used across the other subscribed repos.

Semgrep configs: \`p/golang\`, \`p/trailofbits\`.

Uses org-level secrets already provisioned for existing subscribers (\`CURSOR_API_KEY\`, \`CURSOR_PREFERRED_MODEL\`, \`ADMIN_APP_ID\`, \`ADMIN_APP_PRIVATE_KEY\`, \`SOCKET_API_TOKEN\`) via \`secrets: inherit\`.

## Test plan

- [ ] CI runs on this PR itself (first scan of the repo). Verify the \`Semgrep / scan\` check appears and completes.
- [ ] If findings are produced, confirm the triage agent posts comments as expected.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new GitHub Actions workflow that runs a reusable Semgrep scan on PRs to `main`; no production code changes, with minimal risk aside from potential CI noise or new findings blocking merges.
> 
> **Overview**
> Adds a new `.github/workflows/semgrep.yml` workflow that runs Semgrep SAST on every pull request targeting `main` via the reusable `kernel/security-workflows` pipeline.
> 
> The scan is configured with `p/golang` and `p/trailofbits` rules, grants `pull-requests: write` for automated commenting/triage, and uses `secrets: inherit` to access org-provided credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c9646fd2447aae06109157aab37d47918973afd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->