### PR TITLE
ci: add centralized vuln remediation workflow

### DIFF
--- a/.github/workflows/vuln-remediation.yml
+++ b/.github/workflows/vuln-remediation.yml
@@ -1,0 +1,17 @@
+name: Vulnerability Remediation
+
+on:
+  schedule:
+    - cron: '0 3 * * 3'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  remediate:
+    uses: kernel/security-workflows/.github/workflows/vuln-remediation.yml@main
+    with:
+      go-version-file: 'go.mod'
+    secrets: inherit

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,1 @@
+version: 2


### PR DESCRIPTION
Thin caller to the reusable 3-stage pipeline (triage → fix → PR) in kernel/security-workflows.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds GitHub Actions automation and a minimal `socket.yml` config without changing application/runtime code. Main risk is workflow permissions (`contents`/`pull-requests` write) and reliance on an external reusable workflow pinned to `main`.
> 
> **Overview**
> Adds a new scheduled and manually-triggerable GitHub Actions workflow (`.github/workflows/vuln-remediation.yml`) that calls the reusable `kernel/security-workflows` vulnerability remediation pipeline, granting **write** access to repository contents and pull requests and inheriting secrets.
> 
> Introduces a minimal `socket.yml` (`version: 2`) configuration file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edff257861690422310cf0626799ba3a4194584b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->