### PR TITLE
cli: show full snapshot ID in `snapshot list`

### DIFF
--- a/pkg/cmd/format_test.go
+++ b/pkg/cmd/format_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSnapshotListIDNotTruncated guards the snapshot list table: the ID column
+// must keep its full width on a narrow terminal so the printed ID can be copied
+// into `snapshot get`/`restore`. Truncatable columns (NAME, SOURCE) absorb the
+// shrink instead.
+func TestSnapshotListIDNotTruncated(t *testing.T) {
+	os.Setenv("COLUMNS", "40")
+	defer os.Unsetenv("COLUMNS")
+
+	const fullID = "0123456789abcdef01234567" // 24-char snapshot ID
+
+	var buf bytes.Buffer
+	table := NewTableWriter(&buf, "ID", "NAME", "KIND", "SOURCE", "CREATED")
+	table.TruncOrder = []int{1, 3}
+	table.AddRow(fullID, "a-very-long-snapshot-name", "memory", "a-very-long-source-instance-name", "3 minutes ago")
+
+	widths := table.renderWidths()
+	assert.Equal(t, len(fullID), widths[0], "ID column should never be shrunk")
+
+	table.Render()
+	assert.True(t, strings.Contains(buf.String(), fullID), "rendered table should contain the full ID")
+}

--- a/pkg/cmd/snapshotcmd.go
+++ b/pkg/cmd/snapshotcmd.go
@@ -350,7 +350,7 @@ func handleSnapshotList(ctx context.Context, cmd *cli.Command) error {
 			name = "-"
 		}
 		table.AddRow(
-			TruncateID(snapshot.ID),
+			snapshot.ID,
 			name,
 			string(snapshot.Kind),
 			snapshot.SourceInstanceName,

--- a/pkg/cmd/snapshotcmd.go
+++ b/pkg/cmd/snapshotcmd.go
@@ -343,7 +343,7 @@ func handleSnapshotList(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	table := NewTableWriter(os.Stdout, "ID", "NAME", "KIND", "SOURCE", "CREATED")
-	table.TruncOrder = []int{0, 3}
+	table.TruncOrder = []int{1, 3} // NAME first, then SOURCE; never truncate ID (copy-paste target)
 	for _, snapshot := range *snapshots {
 		name := snapshot.Name
 		if name == "" {


### PR DESCRIPTION
## Summary
`hypeman snapshot list` truncated the snapshot ID to 12 chars (`TruncateID`), but `snapshot get` / `snapshot restore` require the full 24-char ID — so copying the displayed ID returned a 404. The list table now shows the full snapshot ID; `-q`/quiet output already printed the full ID and is unchanged.

Found during QA of hypeman#277 (snapshot/standby flows).

## Test
`go build ./...` + `go test ./pkg/cmd/...` green. Verified live: `snapshot list` now shows the 24-char ID and `snapshot get <that id>` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display-only change for snapshot list table formatting; no API or server behavior changes.
> 
> **Overview**
> **`hypeman snapshot list`** now prints the **full 24-character snapshot ID** in the table instead of a 12-character `TruncateID` value, so IDs copied from the list work with **`snapshot get`** and **`snapshot restore`** (which require the full ID).
> 
> On narrow terminals, **`TruncOrder`** is updated from ID+SOURCE to **NAME+SOURCE**, so column shrinking affects those fields while the ID column stays full width. A regression test (`TestSnapshotListIDNotTruncated`) asserts ID width and rendered output at `COLUMNS=40`. Quiet (`-q`) output was already full IDs and is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f85254e70c63ba4cd4a8d6fa79ee8e09f516a18d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->